### PR TITLE
Fix hand control and synchronization in brick routine

### DIFF
--- a/IK/mover_ladrillo.py
+++ b/IK/mover_ladrillo.py
@@ -193,9 +193,9 @@ class MoverLadrillo:
             "tiempo": self.tiempo_mov,
             "brazo": np.round(q, 4).tolist(),
             "cintura": {
-                12: round(cintura_rad, 4),  # WaistYaw
-                13: 0.0,  # WaistRoll
-                14: 0.0   # WaistPitch
+                "12": round(cintura_rad, 4),  # WaistYaw
+                "13": 0.0,  # WaistRoll
+                "14": 0.0   # WaistPitch
             }
         }
         if mano_izq is not None:
@@ -290,9 +290,9 @@ class MoverLadrillo:
             "cintura": {
                 "12": 0.0,  # WaistYaw
                 "13": 0.0,  # WaistRoll
-                "14": 0.0,   # WaistPitch
+                "14": 0.0   # WaistPitch
+            },
             "mano_izq": self.LEFT_HAND_OPEN
-            }
         }
         rutina.append(paso_final)
         return rutina


### PR DESCRIPTION
## Summary
- define left-hand presets within `MoverLadrillo` and propagate optional hand commands through steps
- execute optional hand commands before arm motions and add safe stop in `rutina_ladrillos`
- ensure waist keys are strings and include final park step with open hand

## Testing
- `python -m py_compile IK/mover_ladrillo.py`
- `python -m py_compile IK/rutina_ladrillos.py`
- `python stub smoke_test.py` *(custom stubs to generate `rutina_ladrillo.json` and verify hand command order)*

------
https://chatgpt.com/codex/tasks/task_e_68a248507f5083228ba047c0a1bbdd2d