### PR TITLE
Update pallet boundary logic and add validation test

### DIFF
--- a/IK/pallet.py
+++ b/IK/pallet.py
@@ -151,8 +151,10 @@ class Pallet:
         front = y_center - self.brick.length / 2.0
         back = y_center + self.brick.length / 2.0
 
-        x_min, x_max = 0.0, self.cols * self.pitch_x
-        y_min, y_max = 0.0, self.rows * self.pitch_y
+        x_min = -self.brick.width / 2
+        x_max = (self.cols - 1) * self.pitch_x + self.brick.width / 2
+        y_min = -self.brick.length / 2
+        y_max = (self.rows - 1) * self.pitch_y + self.brick.length / 2
 
         return (x_min <= left <= x_max) and (x_min <= right <= x_max) and \
                (y_min <= front <= y_max) and (y_min <= back <= y_max)

--- a/tests/test_pallet.py
+++ b/tests/test_pallet.py
@@ -1,0 +1,41 @@
+"""Unit tests for pallet boundary validation using dummy modules."""
+
+import sys
+import types
+
+class DummySE3:
+    def __init__(self, x=0, y=0, z=0):
+        self.x = x
+        self.y = y
+        self.z = z
+
+    def __mul__(self, other):
+        if isinstance(other, DummySE3):
+            return DummySE3(self.x + other.x, self.y + other.y, self.z + other.z)
+        return self
+
+class DummySO3:
+    pass
+
+sys.modules['spatialmath'] = types.SimpleNamespace(SE3=DummySE3, SO3=DummySO3)
+sys.modules['numpy'] = types.SimpleNamespace()
+
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "pallet", Path(__file__).resolve().parent.parent / "IK" / "pallet.py"
+)
+pallet = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pallet)
+
+Pallet = pallet.Pallet
+Brick = pallet.Brick
+
+
+def test_is_slot_valid_edges():
+    rows, cols, layers = 2, 2, 2
+    brick = Brick(0.1, 0.2, 0.06)
+    pallet = Pallet(rows, cols, layers, brick)
+    assert pallet.is_slot_valid(0, 0, 0)
+    assert pallet.is_slot_valid(rows - 1, cols - 1, layers - 1)


### PR DESCRIPTION
## Summary
- adjust pallet slot validation to compute bounds using half-brick dimensions
- add unit test ensuring first and last pallet slots are valid
- document use of dummy modules in pallet test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'spatialmath')*
- `pytest tests/test_pallet.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3dd0a22f083228f309c75053581d4